### PR TITLE
Fixed TypeError caused by oversight in Python2->3 migration

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -128,7 +128,7 @@ def update_dns(subdomain, auth, ip_address):
     else:
         update_resp = requests.put(
             CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API.format(zone_id=zone_id, dns_record_id=dns_record_id),
-            headers=dict(auth.items() + [('Content-Type', 'application/json')]),
+            headers=dict(auth.items() | [('Content-Type', 'application/json')]),
             data=json.dumps(new_dns_record),
         )
         if update_resp.json()['success']:


### PR DESCRIPTION
Hey folks, I wasn't able to get this working out of the box due to this error:

```
Updating the A record (ID XXX) of (sub)domain XXX (ID XXX) to XXX.
Traceback (most recent call last):
  File "cloudflare-ddns", line 161, in <module>
    main()
  File "cloudflare-ddns", line 154, in main
    update_dns(domain, auth, external_ip)
  File "cloudflare-ddns", line 131, in update_dns
    headers=list(auth.items() + [('Content-Type', 'application/json')]),
TypeError: unsupported operand type(s) for +: 'dict_items' and 'list'
```

I reckon this was just an oversight in the Python 2->3 migration - this fixed it for me.

Thanks for the code!