### PR TITLE
Fix TypeError bug: dict_items->list

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -128,7 +128,7 @@ def update_dns(subdomain, auth, ip_address):
     else:
         update_resp = requests.put(
             CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API.format(zone_id=zone_id, dns_record_id=dns_record_id),
-            headers=dict(auth.items() + [('Content-Type', 'application/json')]),
+            headers=dict(list(auth.items()) + [('Content-Type', 'application/json')]),
             data=json.dumps(new_dns_record),
         )
         if update_resp.json()['success']:


### PR DESCRIPTION
```
TypeError: unsupported operand type(s) for +: 'dict_items' and 'list'
```

Use `list()` to wrap `dict_items` to `list`