### PR TITLE
 Add timeouts to requests

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -102,7 +102,7 @@ def get_ipv6():
         match = inet6_finder.match(line)
         if match is not None:
             # Multiple address might be present, assuming the first one is the best
-            # Do we need to handle temporary/dynamic addresses?
+            # Maybe add flag for preventing temporary addresses?
             return match.group(1)
     return None
 

--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -88,7 +88,7 @@ def get_external_ip():
 
     :return: A string representing the network's external IP address
     """
-    return requests.get(EXTERNAL_IP_QUERY_API).json()['ip']
+    return requests.get(EXTERNAL_IP_QUERY_API, timeout=6).json()['ip']
 
 
 def get_ipv6():
@@ -118,6 +118,7 @@ def update_dns_record(auth, zone_id, record, ip_address):
         CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API.format(zone_id=zone_id, dns_record_id=record['id']),
         headers=dict(list(auth.items()) + [('Content-Type', 'application/json')]),
         data=json.dumps({'type': record['type'], 'name': record['name'], 'content': ip_address}),
+        timeout=6,
     )
     if update_resp.json()['success']:
         print('DNS record updated successfully!')
@@ -138,7 +139,7 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
     # Extract the domain
     domain = get_fld(subdomain, fix_protocol=True)
     # Find the zone ID corresponding to the domain
-    zone_resp = requests.get(CLOUDFLARE_ZONE_QUERY_API, headers=auth)
+    zone_resp = requests.get(CLOUDFLARE_ZONE_QUERY_API, headers=auth, timeout=6)
     if zone_resp.status_code != 200:
         print('Authentication error: make sure your email and API key are correct. To set new values, run cloudflare-ddns --configure')
         return
@@ -151,7 +152,12 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
     # Find DNS records
     record_a = None
     record_aaaa = None
-    for dns_record in requests.get(CLOUDFLARE_ZONE_DNS_RECORDS_QUERY_API.format(zone_id=zone_id), headers=auth, params={'name': subdomain}).json()['result']:
+    for dns_record in requests.get(
+            CLOUDFLARE_ZONE_DNS_RECORDS_QUERY_API.format(zone_id=zone_id),
+            headers=auth,
+            params={'name': subdomain},
+            timeout=6,
+    ).json()['result']:
         if dns_record['type'] == 'A':
             record_a = dns_record
         elif dns_record['type'] == 'AAAA':


### PR DESCRIPTION
Based on my test, an update process can use around 120MB of RAM on a Linux amd64. Without timeout, cron might spawn many zombie processes that quickly uses up all the RAM. It's time to stop.

Value 6 is due to the fact that one update can issue up to 5 requests sequentially, but arbitrary.