### PR TITLE
Add Dockerfile with instructions in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+RUN apt update && \
+  apt -y dist-upgrade && \
+  apt -y install \
+  iproute2 \
+  python3 \
+  python3-pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
+  update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
+RUN python -m pip install \
+  argparse \
+  requests \
+  tld
+RUN groupadd -g 1001 cloudflare-ddns-client && \
+  useradd -u 1001 -g 1001 -s /bin/bash -m cloudflare-ddns-client && \
+  mkdir -p /usr/local/bin
+USER cloudflare-ddns-client
+COPY --chown=cloudflare-ddns-client cloudflare-ddns /usr/local/bin/cloudflare-ddns-client
+CMD /usr/local/bin/cloudflare-ddns-client --update

--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ Then add the entry
 ```
 0 0 * * * /usr/local/bin/cloudflare-ddns --update-now > /dev/null 2>&1
 ```
+
+### Docker / Kubernetes
+A Dockerfile is included. This is mostly useful for cases where you want to run cloudflare-ddns-client as a cronjob in Kubernetes
+
+Configuration must be created before running in docker and provided either as a Kubernetes secret or mounted as a file into the container.
+
+Usage in local docker
+```
+docker run -v /path/to/your/.cloudflare-ddns:/home/cloudflare-ddns-client/.cloudflare-ddns cloudflare-ddns-client:latest
+```


### PR DESCRIPTION
Having a Dockerized version of this tool is useful for cases where someone wants to run it from Docker or as a cronjob in Kubernetes.