### PR TITLE
Fix to wrong proxied value

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -127,7 +127,7 @@ def update_dns_record(auth, zone_id, record, ip_address):
     update_resp = requests.put(
         CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API.format(zone_id=zone_id, dns_record_id=record['id']),
         headers=dict(list(auth.items()) + [('Content-Type', 'application/json')]),
-        data=json.dumps({'type': record['type'], 'name': record['name'], 'content': ip_address}),
+        data=json.dumps({'type': record['type'], 'name': record['name'], 'content': ip_address, 'proxied': record['proxied']}),
         timeout=6,
     )
     if update_resp.json()['success']:

--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -148,7 +148,7 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
     """
     # Extract the domain
     domain = get_fld(subdomain, fix_protocol=True)
-    
+
     # Find the zone ID corresponding to the domain
     cur_page = 1
     zone_names_to_ids = {}


### PR DESCRIPTION
This fix sets the proxied value of the record to the value it was before updating it.
If you have proxied set to true it will stay true; if you habe proxied set to false it will stay false.

I also remove unecessary spaces.

This is a fix for the Issue #23 