### PR TITLE
added quiet/silent unchanged mode, regarding #47

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import atexit
 import json
 import os
 import re
@@ -34,11 +35,58 @@ def load_arguments():
     parser.add_argument('--configure', action='store_true', help='Interactively configure the account and domain for the DDNS updates.')
     parser.add_argument('--update-now', action='store_true', help='Update DNS records right now.')
     parser.add_argument('--debug', action='store_true', help='Print detailed debug output.')
+    parser.add_argument('--quiet', action='store_true', help='Only log DNS changes / warnings / errors.')
     return parser.parse_args()
 
 
 START_ARGS = load_arguments()
 
+LOG_MESSAGES = []
+def LOG(msg, is_debug = False):
+    """
+    Use this for all internal logging.
+    This handles caching for quiet mode for handle_logs()
+    See Issue #47
+    """
+    if START_ARGS.quiet:
+        LOG_MESSAGES.append((msg, is_debug))
+    else:
+        if is_debug:
+            if START_ARGS.debug:
+                print(msg)
+        else:
+            print(msg)
+
+CHANGE_OR_ERROR_OCCURED = False
+def change_or_error_occured():
+    """
+    Sets boolean for logging so messages will be printed even on quiet mode
+    """
+    global CHANGE_OR_ERROR_OCCURED
+    CHANGE_OR_ERROR_OCCURED = True
+
+LOGS_HANDLED = False  # if logs got printed already
+def handle_logs():
+    """
+    Handles cached log messages for quiet mode.
+    This function uses CHANGE_OR_ERROR_OCCURED to test if something (e.g. an error or dns change) happend that justifies stdout on quiet mode.
+    See Issue #47
+    """
+    global LOGS_HANDLED
+    if LOGS_HANDLED:
+        return
+    LOGS_HANDLED = True
+    if START_ARGS.quiet:
+        if not CHANGE_OR_ERROR_OCCURED:  # nothing to log on quiet mode
+            return
+    for msg in LOG_MESSAGES:
+        if msg[1]:  # if debug
+            if START_ARGS.debug:
+                print(msg[0])
+        else:
+            print(msg[0])
+
+atexit.register(handle_logs)
 
 def load_configuration():
     """
@@ -59,11 +107,13 @@ def load_configuration():
             elif config['Cloudflare DDNS']['auth_type'] == 'key' and all([key in config['Cloudflare DDNS'] for key in ['email', 'api_key']]):
                 return config['Cloudflare DDNS']
         else:
-            print('Configuration file {config_file} is missing parameters. Run cloudflare-ddns --configure'
+            change_or_error_occured()
+            LOG('Configuration file {config_file} is missing parameters. Run cloudflare-ddns --configure'
                   ' to set the configuration.'.format(config_file=CONFIGURATION_FILE))
             return {}
     except KeyError:
-        print('Configuration file {config_file} not found or invalid! Did you run cloudflare-ddns --configure?'
+        change_or_error_occured()
+        LOG('Configuration file {config_file} not found or invalid! Did you run cloudflare-ddns --configure?'
               .format(config_file=CONFIGURATION_FILE))
         return {}
 
@@ -76,9 +126,9 @@ def initialize_configuration():
     """
     config = configparser.ConfigParser()
     config['Cloudflare DDNS'] = {}
-    print('=============Configuring CloudFlare automatic DDNS update client=============')
-    print('You may rerun this at any time with cloudflare-ddns --configure')
-    print('Quit and cancel at any time with Ctrl-C\n')
+    LOG('=============Configuring CloudFlare automatic DDNS update client=============')
+    LOG('You may rerun this at any time with cloudflare-ddns --configure')
+    LOG('Quit and cancel at any time with Ctrl-C\n')
     auth_type = None
     while not auth_type:
         auth_type_input = input('Use API token or API key to authenticate?\n'
@@ -112,7 +162,7 @@ def initialize_configuration():
     with open(CONFIGURATION_FILE, 'w') as config_file:
         config.write(config_file)
     os.chmod(CONFIGURATION_FILE, stat.S_IREAD | stat.S_IWRITE)
-    print('\nConfiguration file written to {config_file} successfully.'.format(config_file=CONFIGURATION_FILE))
+    LOG('\nConfiguration file written to {config_file} successfully.'.format(config_file=CONFIGURATION_FILE))
 
 
 def get_external_ip():
@@ -124,12 +174,12 @@ def get_external_ip():
     for api in EXTERNAL_IP_QUERY_APIS:
         try:
             if START_ARGS.debug:
-                print("Fetching {}".format(api))
+                LOG("Fetching {}".format(api), is_debug=True)
             r = requests.get(api, timeout=6)
-            return r.text.strip() # Fix bug with trailing whitespace, Fixes #39
+            return r.text.strip()  # Fix bug with trailing whitespace, Fixes #39
         except requests.exceptions.RequestException:
-            print('Cannot fetch your external ip. {} not reachable.'.format(api))
-    print("All {} checked services did not return any external ip address. Please check your internet connection."
+            LOG('Cannot fetch your external ip. {} not reachable.'.format(api))
+    LOG("All {} checked services did not return any external ip address. Please check your internet connection."
           .format(len(EXTERNAL_IP_QUERY_APIS)))
     return
 
@@ -153,11 +203,12 @@ def get_ipv6():
 def update_dns_record(auth, zone_id, record, ip_address):
     if record is None or ip_address is None:
         return
-    print('Updating the {type} record (ID {dns_record_id}) of (sub)domain {subdomain} (ID {zone_id}) to {ip_address}.'
+    LOG('Updating the {type} record (ID {dns_record_id}) of (sub)domain {subdomain} (ID {zone_id}) to {ip_address}.'
           .format(type=record['type'], dns_record_id=record['id'], zone_id=zone_id, subdomain=record['name'], ip_address=ip_address))
     if record['content'] == ip_address:
-        print('DNS record is already up-to-date; taking no action')
+        LOG('DNS record is already up-to-date; taking no action')
         return
+    change_or_error_occured()
     update_resp = requests.patch(
         CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API.format(zone_id=zone_id, dns_record_id=record['id']),
         headers=dict(list(auth.items()) + [('Content-Type', 'application/json')]),
@@ -165,9 +216,9 @@ def update_dns_record(auth, zone_id, record, ip_address):
         timeout=6,
     )
     if update_resp.json().get('success'):
-        print('DNS record updated successfully!')
+        LOG('DNS record updated successfully!')
     else:
-        print('DNS record failed to update.\nCloudFlare returned the following errors: {errors}.\n\n'
+        LOG('DNS record failed to update.\nCloudFlare returned the following errors: {errors}.\n\n'
               'CloudFlare returned the following messages: {messages}'.format(errors=update_resp.json()['errors'],
                                                                               messages=update_resp.json()['messages']))
 
@@ -188,26 +239,27 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
     # Find the zone ID corresponding to the domain
     cur_page = 1
     zone_names_to_ids = {}
-    print('Listing all zones.')
+    LOG('Listing all zones.')
     while True:
         zone_resp = requests.get(CLOUDFLARE_ZONE_QUERY_API, headers=auth, timeout=6, params={'per_page': 50, 'page': cur_page})
         if zone_resp.status_code != 200:
+            change_or_error_occured()
             try:
                 errors = [x.get("message") for x in zone_resp.json()["errors"]]
-                print('===================================')
-                print('Request failed.')
-                print('Check your permissions and API key.')
+                LOG('===================================')
+                LOG('Request failed.')
+                LOG('Check your permissions and API key.')
                 if START_ARGS.debug:
-                    print('Status code: {}'.format(zone_resp.status_code))
-                    print('Text: "{}"'.format(zone_resp.text))
+                    LOG('Status code: {}'.format(zone_resp.status_code), is_debug=True)
+                    LOG('Text: "{}"'.format(zone_resp.text), is_debug=True)
                 else:
-                    print('Use --debug for more details')
+                    LOG('Use --debug for more details')
                 for e in [x for x in errors if x]:
-                    print(e)  # this will print detailed info about missing permission etc.
+                    LOG(e)  # this will print detailed info about missing permission etc.
                     # e.g. "requires permission 'com.cloudflare.api.account.zone.list' to list zones"
             except KeyError:
-                print('Authentication error: make sure your email and API key are correct. '
-                      'To set new values, run cloudflare-ddns --configure')
+                LOG('Authentication error: make sure your email and API key are correct. '
+                    'To set new values, run cloudflare-ddns --configure')
             return
         data = zone_resp.json()
         total_pages = data['result_info']['total_pages']
@@ -219,13 +271,14 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
             break
 
     if domain not in zone_names_to_ids:
-        print('The domain {domain} doesn\'t appear to be one of your CloudFlare domains. We only found {domain_list}.'
-              .format(domain=domain, domain_list=map(str, zone_names_to_ids.keys())))
+        change_or_error_occured()
+        LOG('The domain {domain} doesn\'t appear to be one of your CloudFlare domains. We only found {domain_list}.'
+            .format(domain=domain, domain_list=list(zone_names_to_ids.keys())))
         return
     zone_id = zone_names_to_ids[domain]
 
     # Find DNS records
-    print('Finding all DNS records for domain "{}".'.format(subdomain))
+    LOG('Finding all DNS records for domain "{}".'.format(subdomain))
     record_a = None
     record_aaaa = None
     r = requests.get(
@@ -235,21 +288,22 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
             timeout=6,
     )
     if r.status_code != 200:
+        change_or_error_occured()
         try:
             errors = [x.get("message") for x in r.json()["errors"]]
-            print('===================================')
-            print('Request failed.')
-            print('Check your permissions and API key.')
+            LOG('===================================')
+            LOG('Request failed.')
+            LOG('Check your permissions and API key.')
             if START_ARGS.debug:
-                print('Status code: {}'.format(r.status_code))
-                print('Text: "{}"'.format(r.text))
+                LOG('Status code: {}'.format(r.status_code), is_debug=True)
+                LOG('Text: "{}"'.format(r.text), is_debug=True)
             else:
-                print('Use --debug for more details')
+                LOG('Use --debug for more details')
             for e in [x for x in errors if x]:
-                print(e)  # this will print detailed info about missing permission etc.
+                LOG(e)  # this will print detailed info about missing permission etc.
                 # e.g. "requires permission 'com.cloudflare.api.account.zone.list' to list zones"
         except KeyError:
-            print('Authentication error: make sure your email and API key are correct. To set new values, run cloudflare-ddns --configure')
+            LOG('Authentication error: make sure your email and API key are correct. To set new values, run cloudflare-ddns --configure')
         return
     for dns_record in r.json()['result']:
         if dns_record['type'] == 'A':
@@ -258,11 +312,12 @@ def update_dns(subdomain, auth, ipv4_address, ipv6_address):
             record_aaaa = dns_record
 
     if record_a is None and record_aaaa is None:
-        print('No A or AAAA records defined for domain "{}".'.format(subdomain))
+        change_or_error_occured()
+        LOG('No A or AAAA records defined for domain "{}".'.format(subdomain))
         if START_ARGS.debug:
-            print(r.json())
+            LOG(r.json(), is_debug=True)
         else:
-            print('Use --debug for more details')
+            LOG('Use --debug for more details')
         return
     
     # Update the record as necessary
@@ -279,6 +334,7 @@ def main():
     elif START_ARGS.update_now:
         config = load_configuration()
         if not config:
+            change_or_error_occured()
             raise RuntimeError('There was a problem with the configuration file {config_file}! '
                                'Try running cloudflare-ddns --configure'.format(config_file=CONFIGURATION_FILE))
         if config['auth_type'] == 'token':
@@ -286,32 +342,44 @@ def main():
         elif config['auth_type'] == 'key':
             auth = {'X-Auth-Email': config['email'], 'X-Auth-Key': config['api_key']}
         else:
+            change_or_error_occured()
             raise RuntimeError('There was a problem with the configuration file {config_file}! '
                                'Try running cloudflare-ddns --configure'.format(config_file=CONFIGURATION_FILE))
         external_ip = get_external_ip()
         if external_ip:
-            print('Found external IPv4: "{}"'.format(str(external_ip)))
+            LOG('Found external IPv4: "{}"'.format(str(external_ip)))
         ipv6 = get_ipv6()
         if ipv6:
-            print('Found external IPv6: "{}"'.format(str(ipv6)))
+            LOG('Found external IPv6: "{}"'.format(str(ipv6)))
         if not external_ip and not ipv6:
+            change_or_error_occured()
             raise RuntimeError("Neither external IPv4 nor IPv6 found. Please check your internet connection.")
         try:
             domains = config['domains'].split(',')
         except KeyError:
+            change_or_error_occured()
             raise RuntimeError('There was a problem with the configuration file {config_file}! '
                                'Try running cloudflare-ddns --configure'.format(config_file=CONFIGURATION_FILE))
 
         if not domains:
+            change_or_error_occured()
             raise RuntimeError("No domains found to update.")
         
-        print("Handling domains: {}.".format(domains))
+        LOG("Handling domains: {}.".format(domains))
         for domain in domains:
+            LOG("Handling {}.".format(domain), is_debug=True)
             update_dns(domain, auth, external_ip, ipv6)
+            LOG("Finished handling {}.".format(domain), is_debug=True)
     else:
-        print('No arguments passed; exiting.')
-        print('Try cloudflare-ddns --help.')
+        change_or_error_occured()
+        LOG('No arguments passed; exiting.')
+        LOG('Try cloudflare-ddns --help.')
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as ex:
+        change_or_error_occured()
+        handle_logs()
+        raise ex


### PR DESCRIPTION
Hey,
I added a `--quiet` flag that will stop all output if there is no DNS change, error, warning, etc.

These changes are done regarding #47.

The script is still usable with `--debug`.
If a change @ CloudFlare is done or an error is thrown it will log all messages as before.

I am not 100% happy with my implementation although I do not know how to do it better. I tried using custom LogLevels but that would mean that we lose all messages until the very point in execution where the script knows a DNS change occures.

I am open for suggestions on how to improve my implementation!