### PR TITLE
README changes and use env var for API_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then add the entry
 ```
 
 ### Docker / Kubernetes
-A Dockerfile is included. This is mostly useful for cases where you want to run cloudflare-ddns-client as a cronjob in Kubernetes
+A Dockerfile is included. This is mostly useful for cases where you want to run cloudflare-ddns-client as a cronjob in Kubernetes.
 
 Configuration must be created before running in docker and provided either as a Kubernetes secret or mounted as a file into the container.
 
@@ -66,4 +66,4 @@ docker run -v /path/to/your/.cloudflare-ddns:/home/cloudflare-ddns-client/.cloud
 
 ### Contributions
 
-Contributions of all form are welcome :)
+Contributions of all forms are welcome :)

--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -54,7 +54,9 @@ def load_configuration():
 
         # Ensure all fields are present
         if 'domains' in config['Cloudflare DDNS']:
-            if config['Cloudflare DDNS']['auth_type'] == 'token' and 'api_token' in config['Cloudflare DDNS']:
+            if config['Cloudflare DDNS']['auth_type'] == 'token':
+                if 'api_token' not in config['Cloudflare DDNS'] and os.environ.get('API_TOKEN'):
+                    config['Cloudflare DDNS']['api_token'] = os.environ.get('API_TOKEN')
                 return config['Cloudflare DDNS']
             elif config['Cloudflare DDNS']['auth_type'] == 'key' and all([key in config['Cloudflare DDNS'] for key in ['email', 'api_key']]):
                 return config['Cloudflare DDNS']


### PR DESCRIPTION
Allow API_TOKEN to be read from an environment variable instead of the config file. This is useful for a kubernetes deployment where this will be set from a k8s secret.