### PR TITLE
Move from Ubuntu to Python Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,11 @@
-FROM ubuntu:18.04
-RUN apt update && \
-  apt -y dist-upgrade && \
-  apt -y install \
-  iproute2 \
-  python3 \
-  python3-pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
-  update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
-RUN python -m pip install \
-  argparse \
-  requests \
-  tld
-RUN groupadd -g 1001 cloudflare-ddns-client && \
-  useradd -u 1001 -g 1001 -s /bin/bash -m cloudflare-ddns-client && \
+FROM python:alpine3.11
+RUN apk add iproute2
+RUN python3 -m pip install \
+   argparse \
+   requests \
+   tld
+RUN addgroup -g 1001 cloudflare-ddns-client && \
+  adduser -D -u 1001 -G cloudflare-ddns-client cloudflare-ddns-client && \
   mkdir -p /usr/local/bin
 USER cloudflare-ddns-client
 COPY --chown=cloudflare-ddns-client cloudflare-ddns /usr/local/bin/cloudflare-ddns-client


### PR DESCRIPTION
The Python Alpine issue is smaller than the Ubuntu image, and has fewer non-required components.