### PR TITLE
Fix: The IPv6 address detection should ignore unique local IPv6 Address

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -142,13 +142,34 @@ def get_ipv6():
 
     :return: A string representing one of the network's IPv6 addresses
     """
+
+    # Some network configurations might allow the gateway to provide unique local addresses(ULA) to the devices on the LAN.
+    # In this case, one network adapter could have two non-temporary IPv6 addresses:
+    #   The IPv6 Address on the Internet(2000::/3) and The unique local address.
+    #   The second one cannot be accessed outside, it is designed to provide convenience on accessing devices on the same network.
+    # The ULA prefix is statically configured by the gateway, which means devices on the same local network could have
+    # a fixed IPv6 address locally even though the IPv6 address prefix on the Internet might change over time.
+    # According to rfc 4193, the IPv6 address range fc00::/7 is reserved for this kind of purpose.
+    def is_ula_addr(ipAddr):
+        # Only check the first 16 bits of the IPv6 address to judge if the address is one of the ULA addresses
+        return (int(ipAddr[:4], 16) & 0xfe00 ) == 0xfc00
+
+    matchedIPs = []
+
     inet6_finder = re.compile('^    inet6 ([0-9a-f:]+)')
-    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', '-deprecated']).decode('utf-8').split('\n'):
+
+    # add the 'mngtmpaddr' argument to filter temporary IPv6 addresses
+    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', 'mngtmpaddr', '-deprecated']).decode('utf-8').split('\n'):
         match = inet6_finder.match(line)
         if match is not None:
             # Multiple address might be present, assuming the first one is the best
-            # Maybe add flag for preventing temporary addresses?
-            return match.group(1)
+            ipv6_addr = match.group(1)
+            if not is_ula_addr(ipv6_addr):
+                matchedIPs.append(ipv6_addr)
+
+    if len(matchedIPs) > 0:
+        return matchedIPs[0]
+
     return None
 
 

--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -151,24 +151,21 @@ def get_ipv6():
     # a fixed IPv6 address locally even though the IPv6 address prefix on the Internet might change over time.
     # According to rfc 4193, the IPv6 address range fc00::/7 is reserved for this kind of purpose.
     def is_ula_addr(ipAddr):
-        # Only check the first 16 bits of the IPv6 address to judge if the address is one of the ULA addresses
-        return (int(ipAddr[:4], 16) & 0xfe00 ) == 0xfc00
-
-    matchedIPs = []
+        try:
+            prefixValue = int(ipAddr[:ipAddr.find(':', 0)], 16)
+            return (prefixValue & 0xfe00 ) == 0xfc00
+        except ValueError as e:
+            return False
 
     inet6_finder = re.compile('^    inet6 ([0-9a-f:]+)')
 
-    # add the 'mngtmpaddr' argument to filter temporary IPv6 addresses
-    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', 'mngtmpaddr', '-deprecated']).decode('utf-8').split('\n'):
+    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', '-deprecated']).decode('utf-8').split('\n'):
         match = inet6_finder.match(line)
         if match is not None:
             # Multiple address might be present, assuming the first one is the best
             ipv6_addr = match.group(1)
             if not is_ula_addr(ipv6_addr):
-                matchedIPs.append(ipv6_addr)
-
-    if len(matchedIPs) > 0:
-        return matchedIPs[0]
+                return ipv6_addr
 
     return None
 


### PR DESCRIPTION
Some network configurations might let the gateway assigns Unique Local Addresses to devices connected to the local network. 
The purpose of assigning this kind of address is to help devices on the same local network could communicate more conveniently since the IPv6 address on the Internet might change over time. This kind of IPv6 address could not be accessed outside the local network. 

See RFC 4193: https://tools.ietf.org/html/rfc4193