### PR TITLE
Update external ip query APIs to fetch IPv4 addresses only

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -11,8 +11,8 @@ from tld import get_fld
 
 CONFIGURATION_FILE = os.path.expanduser('~/') + '.cloudflare-ddns'
 
-EXTERNAL_IP_QUERY_APIS = ['https://api.ipify.org', 'https://ifconfig.io/ip', 'https://ident.me/',
-                          'https://ifconfig.me/ip', 'https://icanhazip.com/']
+EXTERNAL_IP_QUERY_APIS = ['https://api.ipify.org', 'https://checkip.amazonaws.com', 'https://v4.ident.me/',
+                          'https://ifconfig.me/ip', 'https://ipv4.icanhazip.com/']
 CLOUDFLARE_ZONE_QUERY_API = 'https://api.cloudflare.com/client/v4/zones'  # GET
 CLOUDFLARE_ZONE_DNS_RECORDS_QUERY_API = 'https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records'  # GET
 CLOUDFLARE_ZONE_DNS_RECORDS_UPDATE_API = 'https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{dns_record_id}'  # PATCH


### PR DESCRIPTION
Updated external IP Query API urls to

- ifconfig.io - removed because can't force IPv4 if you have IPv6 address
- checkip.amazonaws.com (replacement of above, doesn't support IPv6 at the moment, so should always resolve to IPv4)
- ident.me - changed domain to force IPv4
- icanhazip - changed domain to force IPv4