### PR TITLE
Exclude temporary addresses from IPv6 detection and list only primary…

### DIFF
--- a/cloudflare-ddns
+++ b/cloudflare-ddns
@@ -178,7 +178,7 @@ def get_ipv6():
 
     inet6_finder = re.compile('^    inet6 ([0-9a-f:]+)')
 
-    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', '-deprecated']).decode('utf-8').split('\n'):
+    for line in subprocess.check_output(['ip', '-6', 'addr', 'list', 'scope', 'global', '-deprecated', '-temporary', 'primary']).decode('utf-8').split('\n'):
         match = inet6_finder.match(line)
         if match is not None:
             # Multiple address might be present, assuming the first one is the best


### PR DESCRIPTION
Added `-temporary` and `primary` flags to remove temporary addresses from the output and only list primary IPv6 addresses

Original:
```
ip -6 addr list scope global -deprecated
```

Proposed change:
```
ip -6 addr list scope global -deprecated -temporary primary
```

In Linux terminal, original had an output like so in my local:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
    inet6 2001:4454:65c:ed00:791e:27b5:9362:f1c7/64 scope global temporary dynamic
       valid_lft 86391sec preferred_lft 14391sec
    inet6 2001:4454:65c:ed00:c9b6:a431:b7e0:e26/64 scope global dynamic mngtmpaddr noprefixroute
       valid_lft 86391sec preferred_lft 14391sec
    inet6 2001:4454:65c:ed00::1/56 scope global noprefixroute
       valid_lft forever preferred_lft forever
```

1. [Temporary IPv6 address](https://docs.oracle.com/cd/E53394_01/html/E54745/ipv6-config-tasks-102.html#:~:text=An%20IPv6%20temporary%20address%20includes,of%20an%20interface's%20MAC%20address.&text=For%20example%2C%20you%20might%20want,addresses%20implement%20IPv6%20privacy%20enhancements.) - Temporary addresses implement IPv6 privacy enhancements. These enhancements are described in RFC 3041, which is available at “Privacy Extensions for Stateless Address Autoconfiguration in IPv6”
2. IPv6 from SLAAC or DHCPv6
3. Statically configured IPv6 address

After the change:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
    inet6 2001:4454:65c:ed00:c9b6:a431:b7e0:e26/64 scope global dynamic mngtmpaddr noprefixroute
       valid_lft 86394sec preferred_lft 14394sec
    inet6 2001:4454:65c:ed00::1/56 scope global noprefixroute
       valid_lft forever preferred_lft forever
```
1. IPv6 from SLAAC or DHCPv6
2. Statically configured IPv6 address

I would prefer to use the 2nd IP Address as this is statically configured, but I guess it's for another PR. The current algorithm assumes the _first one is the best_. In my opinion algorithm should prefer the address with the longest lifetime `[LFT]`, the longest being forever.